### PR TITLE
fixed issue where some assets were not loading in minigame

### DIFF
--- a/assets/minigames/flappybee/flappybee_test.html
+++ b/assets/minigames/flappybee/flappybee_test.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Boilerplate Phaser game</title>
+    <title>Coder Journey: Flappy Bee</title>
     <script src="../phaser.min.js"></script>
 </head>
 


### PR DESCRIPTION
Two .png files are not being picked up by the browser. I think this is because the .png extension was capitalized for some reason.